### PR TITLE
  Sebastián Grignoli	neitanod	Added ! to function declaration

### DIFF
--- a/plugin/autoproto.vim
+++ b/plugin/autoproto.vim
@@ -102,7 +102,7 @@ function! Rm_leading_spaces (string)
  
 endfunction
 
-function Rm_trailing_spaces (string)
+function! Rm_trailing_spaces (string)
 
   let line=a:string
   let string_len = strlen (line)


### PR DESCRIPTION
To avoid error when reloading plugins via Vim-Plug

Error was:

Error detected while processing /home/sebas/dotfiles/vim/plugged/autoproto.vim/plugin/autoproto.vim:
line  137:
E122: Function Rm_trailing_spaces already exists, add ! to replace it
