### PR TITLE
Get rid of error message when function is reloaded and cleanup whitespace

### DIFF
--- a/plugin/autoproto.vim
+++ b/plugin/autoproto.vim
@@ -17,11 +17,11 @@
 "
 " Name:
 "
-"    autoproto.vim 
+"    autoproto.vim
 "
 "
 " Copyright:
-" 
+"
 "    Jochen Baier, 2006 (email@Jochen-Baier.de)
 "
 "
@@ -43,13 +43,13 @@
 "
 " Supported Languages: C
 "
-" Installation: 
+" Installation:
 "
-" * Drop autoproto.vim into your plugin directory 
+" * Drop autoproto.vim into your plugin directory
 "
 " * The script need a tag file to work:
 "  - for your project: ":!ctags -R ." (or use the gvim button)
-"  - for library functions: 
+"  - for library functions:
 "    run: "ctags -R -f ~/.vim/systags --c-kinds=+p /usr/include /usr/local/include"
 "    put  "set tags+=~/.vim/systags" in your .vimrc file.
 "
@@ -57,14 +57,14 @@
 "   (or "XCreateWindow(").
 "   If the tag exist it will be shown in the preview window.
 "   Note: only *.c files are supported ! The file must exist.
-"   
+"
 "
 
 function! Debug (...)
 
  "remove for debug
  return
- 
+
   let i  = 1
   let msg= ""
   while i <= a:0
@@ -80,7 +80,7 @@ function! Debug (...)
 endfunction
 
 function! Rm_leading_spaces (string)
-  
+
   let first_letter=0
 
   while 1==1
@@ -96,10 +96,10 @@ function! Rm_leading_spaces (string)
     return 0
    endif
 
-  endwhile 
+  endwhile
 
-  return strpart(a:string, first_letter) 
- 
+  return strpart(a:string, first_letter)
+
 endfunction
 
 function Rm_trailing_spaces (string)
@@ -108,7 +108,7 @@ function Rm_trailing_spaces (string)
   let string_len = strlen (line)
   let last_letter=string_len - 1
   let space_count = 0
-  
+
   while 1==1
 
     if line[last_letter] != " "
@@ -116,7 +116,7 @@ function Rm_trailing_spaces (string)
     else
       let last_letter=last_letter  - 1
       let space_count = space_count + 1
-      call Debug ("space_count: " . space_count) 
+      call Debug ("space_count: " . space_count)
 
       if space_count > 1
         call Debug ("too many trailing spaces -> skip")
@@ -130,11 +130,11 @@ function Rm_trailing_spaces (string)
       return 0
     endif
 
-  endwhile                              
+  endwhile
 
-  return strpart(line, 0, last_letter + 1)          
+  return strpart(line, 0, last_letter + 1)
 
-endfunction 
+endfunction
 
 function! Chop_it (da_line)
 
@@ -148,10 +148,10 @@ function! Chop_it (da_line)
 
   call Debug ("after remove trailing spaces: <" .  line. ">" )
 
-  let line=Rm_leading_spaces(line) 
+  let line=Rm_leading_spaces(line)
   if line == "0"
     return 0
-  endif  
+  endif
 
 
   "could be inside a comment
@@ -170,19 +170,19 @@ function! Chop_it (da_line)
   let semi=strridx (line, ";")
   if semi != -1
     let line=strpart(line, semi+1)
-    call Debug("after last semi: <" . line . ">")      
-  endif   
+    call Debug("after last semi: <" . line . ">")
+  endif
 
-  let line=Rm_leading_spaces(line)   
+  let line=Rm_leading_spaces(line)
   call Debug("line after leading_spaces after semi: <" . line . ">")
   if line == "0"
     return 0
   endif
 
   call Debug ("cleand line: <" . line . ">")
- 
 
-  "could be a new function definition...  
+
+  "could be a new function definition...
 
   if strridx (line, "=") == -1
 
@@ -204,8 +204,8 @@ function! Chop_it (da_line)
   if strpart(line, 0, 8) == "volatile"
     call Debug ("volatile found")
     return 0
-  endif    
- 
+  endif
+
   if strpart(line, 0, 6) == "inline"
     call Debug ("inline found")
     return 0
@@ -214,12 +214,12 @@ function! Chop_it (da_line)
   if strpart(line, 0, 6) == "struct"
     call Debug ("inline found")
     return 0
-  endif    
+  endif
 
   if strpart(line, 0, 8) == "unsigned"
     call Debug ("unsigned found")
     return 0
-  endif 
+  endif
 
   if strpart(line, 0, 3) == "int"
     call Debug ("int found")
@@ -239,7 +239,7 @@ function! Chop_it (da_line)
   if strpart(line, 0, 4) == "char"
     call Debug ("char found")
     return 0
-  endif 
+  endif
 
   endif
 
@@ -247,28 +247,28 @@ function! Chop_it (da_line)
  let comma=strridx (line, ",")
  if comma != -1
    let line=strpart(line, comma+1)
-   call Debug("after comma: <" . line . ">")      
- endif   
+   call Debug("after comma: <" . line . ">")
+ endif
 
- let line=Rm_leading_spaces(line) 
+ let line=Rm_leading_spaces(line)
  if line == "0"
    return 0
- endif      
+ endif
 
  "could be inside a string
   if stridx (line, "\"")  != -1
     call Debug("probably inside a string")
     return 0
-  endif    
+  endif
 
   "last space
   let last_blank=  strridx(line, " ")
   if last_blank != -1
     call Debug ("last_blank found")
     let line = strpart(line, last_blank + 1)
-  endif   
+  endif
 
-  call Debug ("last_string:<" . line . ">") 
+  call Debug ("last_string:<" . line . ">")
 
   if strlen (line) == 0
     call Debug ("last_string zero length -> skip")
@@ -319,21 +319,21 @@ function! Chop_it (da_line)
       let start_pos=tmp
     endif
   endif
-            
+
   let tmp= strridx(line, "<")
   if tmp != -1
     if tmp > start_pos
       let start_pos=tmp
     endif
   endif
-            
+
   let tmp= strridx(line, ":")
   if tmp != -1
     if tmp > start_pos
       let start_pos=tmp
     endif
   endif
-            
+
   let tmp= strridx(line, "?")
   if tmp != -1
     if tmp > start_pos
@@ -348,7 +348,7 @@ function! Chop_it (da_line)
       let start_pos=tmp
     endif
   endif
-            
+
   let tmp= strridx(line, "(")
   if tmp != -1
     if tmp > start_pos
@@ -361,14 +361,14 @@ function! Chop_it (da_line)
     if tmp > start_pos
       let start_pos=tmp
     endif
-  endif    
+  endif
 
   let tmp= strridx(line, "|")
   if tmp != -1
     if tmp > start_pos
       let start_pos=tmp
     endif
-  endif 
+  endif
 
   let tmp= strridx(line, "/")
   if tmp != -1
@@ -396,14 +396,14 @@ function! Chop_it (da_line)
     if tmp > start_pos
       let start_pos=tmp
     endif
-  endif 
+  endif
 
   let tmp= strridx(line, "*")
   if tmp != -1
     if tmp > start_pos
       let start_pos=tmp
     endif
-  endif      
+  endif
 
   if start_pos >= (strlen (line)-1)
         call Debug("start_pos >= strlen")
@@ -411,8 +411,8 @@ function! Chop_it (da_line)
   endif
 
   call Debug ("start_pos: " . start_pos)
-            
-  let line = strpart(line, start_pos+1) 
+
+  let line = strpart(line, start_pos+1)
   call  Debug("last word:<". line . ">")
 
   let word_len =strlen (line)
@@ -431,44 +431,44 @@ function! Chop_it (da_line)
 
     if line == "for"
       return 0
-    endif  
+    endif
 
     if line == "while"
       return 0
     endif
-   
+
     if line == "switch"
       return 0
-    endif 
+    endif
 
     if line == "sizeof"
       return 0
-    endif  
+    endif
 
     if line == "int"
       return 0
     endif
-  
+
     if line == "long"
       return 0
     endif
-  
+
     if line == "float"
       return 0
     endif
-  
+
     if line == "char"
       return 0
-    endif 
+    endif
 
     if line == "return"
       return 0
-    endif   
+    endif
 
-    break  
+    break
   endwhile
 
-  return line                    
+  return line
 
 endfunction
 
@@ -485,7 +485,7 @@ function! Display_tag (tag)
   if ignorec==1
     call Debug ("ignorecase is set")
     set noignorecase
-  endif      
+  endif
 
   try
     exe "ptag " . a:tag
@@ -494,24 +494,24 @@ function! Display_tag (tag)
 
     if ignorec == 1
       set ignorecase
-    endif   
+    endif
 
     return 0
   endtry
 
   if ignorec == 1
       set ignorecase
-  endif  
+  endif
 
-  silent! wincmd P		
-  if &previewwindow	
- 
+  silent! wincmd P
+  if &previewwindow
+
 	  if has("folding")
 	    silent! .foldopen
 	  endif
 
     let cur_pos=winline()
-    if cur_pos <= 1 
+    if cur_pos <= 1
       let cur_pos = 0
     else
       let cur_pos=cur_pos -1
@@ -527,13 +527,13 @@ function! Display_tag (tag)
       execute "normal " . cur_pos . "\<C-e>"
     endif
 
-    wincmd p 
+    wincmd p
 
   endif
 
   return 1
 
-endfunction 
+endfunction
 
 function! Semi_typed()
 
@@ -579,7 +579,7 @@ function! Map_semi()
     call Debug ("mapping semi failed")
    endtry
 
-endfunction 
+endfunction
 
 
 function! Unmap_semi()
@@ -590,9 +590,9 @@ function! Unmap_semi()
     call Debug ("unmap semi failed")
    endtry
 
-endfunction    
- 
- 
+endfunction
+
+
 function! Close_bracket()
 
   call Debug ("close bracket")
@@ -603,9 +603,9 @@ function! Close_bracket()
     return
   endif
 
-  execute "normal %"  
-  let brace_pos=getpos(".") 
-  execute "normal %"     
+  execute "normal %"
+  let brace_pos=getpos(".")
+  execute "normal %"
 
   let brace_line=brace_pos[1]
   let brace_column=brace_pos[2]
@@ -614,12 +614,12 @@ function! Close_bracket()
 
   let tag_iter = 0
   let tag_index = -1
-    
+
   for list_line in b:recent_braces
-  
+
     if list_line[1] == brace_line
       if list_line[2] == brace_column
-  
+
         let  tag_index=tag_iter
         break
       endif
@@ -636,16 +636,16 @@ function! Close_bracket()
     return
   endif
 
-  if tag_index == 0 
+  if tag_index == 0
     call Debug ("last recent tag: delete recent_braces list, unmap")
     unlet b:recent_braces
     call Unmap_close_bracket()
-  
+
     silent! wincmd P
     if &previewwindow
       match none
      wincmd p
-    endif     
+    endif
 
 
     return
@@ -659,13 +659,13 @@ function! Close_bracket()
 
   call Display_tag (tag_to_display)
 
-  
+
 endfunction
 
 
 function! Open_bracket (...)
 
-  let brace_pos=getpos(".") 
+  let brace_pos=getpos(".")
 
   call Debug ("function: Open_bracket")
 
@@ -673,11 +673,11 @@ function! Open_bracket (...)
   let line_len=strlen (line)
   call Debug ("line: <" . line . ">")
   call Debug ("line_len: " . line_len)
-  
-  call Debug ("brace_pos[2]:" . brace_pos[2]) 
 
-  let cursor_column=brace_pos[2]  
-    
+  call Debug ("brace_pos[2]:" . brace_pos[2])
+
+  let cursor_column=brace_pos[2]
+
   if line_len < 1
     call Debug ("line too short -> skip")
     return 0
@@ -691,16 +691,16 @@ function! Open_bracket (...)
   endif
 
   let eol=1
-  
+
   if line_len > cursor_column
     let line=strpart (line, 0, cursor_column-1)
-    "call Semi_typed () 
+    "call Semi_typed ()
     let eol=0
     call Debug ("line before cursor: <" . line . ">" )
-  endif                      
+  endif
 
   let line=Chop_it (line)
-         
+
 
   if line == "0"
     call Debug ("tag is 0 -> skip")
@@ -712,9 +712,9 @@ function! Open_bracket (...)
     return
   endif
 
-  call Debug ("tag is:<" . line . ">") 
+  call Debug ("tag is:<" . line . ">")
 
-  if line =~ '\a' 
+  if line =~ '\a'
     call Debug ("letters...")
   else
     call Debug ("no letters found -> skip")
@@ -725,7 +725,7 @@ function! Open_bracket (...)
 
     let brace_line=brace_pos[1]
     let brace_column=brace_pos[2] + eol
-    
+
     call Debug ("brace_line: " . brace_line . " brace_column: " . brace_column )
 
     if !exists ("b:recent_braces")
@@ -746,6 +746,6 @@ function! Map_comma (...)
 
   inoremap <silent> <buffer> ( <C-o>:call Open_bracket()<CR>(
 
-endfunction                                   
+endfunction
 
 autocmd BufRead *.c call Map_comma()

--- a/plugin/autoproto.vim
+++ b/plugin/autoproto.vim
@@ -102,7 +102,7 @@ function! Rm_leading_spaces (string)
 
 endfunction
 
-function Rm_trailing_spaces (string)
+function! Rm_trailing_spaces (string)
 
   let line=a:string
   let string_len = strlen (line)


### PR DESCRIPTION
This pull request has two patches:
1. Removes trailing whitespace from lines
2. Gets rid of the error message when the function is reloaded

When .vimrc is reloaded, vim generates an error because `Rm_trailing_spaces` is being redefined. Using `function!` instead of `function` tells vim that the function can be safely reloaded. This stops vim from generating the error message.
